### PR TITLE
add test execution examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ For more information on `--config=../cormorant_test_config.yaml` see [Test Confi
 
 For more information on `--env=../cormorant_env.yaml` see [Test Environment](doc/test_environment.md)
 
+For more examples on how to run tests see [Test Execution](doc/test_execution.md)
+
 ## Testing the Framework
 
 TODO: implement tests for all packages

--- a/doc/test_execution.md
+++ b/doc/test_execution.md
@@ -1,0 +1,21 @@
+# Test Execution
+
+## Common Example Commands
+
+### Run all the tests with verbose option:
+
+```
+ginkgo -v run tests -- --ginkgo.focus-file=tbc.go --config=../razorbill_test_config.yaml --env=../razorbill_env.yaml
+```
+
+### Run the Telecom GrandMaster and GNSS tests:
+
+```
+ginkgo run tests -- --ginkgo.focus-file=tbc.go --config=../razorbill_test_config.yaml --env=../razorbill_env.yaml
+```
+
+### Run the Telecom Boundary Clock tests wih verbose option:
+
+```
+ginkgo -v run tests -- --ginkgo.focus-file=tbc.go --config=../razorbill_test_config.yaml --env=../razorbill_env.yaml
+```


### PR DESCRIPTION
Update doc by adding a section on examples of execution by means of filtering tests, run with verbose. The list of options may grow adding other labels.