### PR TITLE
Make logs less noisy by default

### DIFF
--- a/pkg/clients/exec_command.go
+++ b/pkg/clients/exec_command.go
@@ -82,13 +82,13 @@ func (clientsholder *Clientset) ExecCommandContainer(ctx ContainerContext, comma
 	commandStr := command
 	var buffOut bytes.Buffer
 	var buffErr bytes.Buffer
-	log.Debug(fmt.Sprintf(
+	log.Debugf(
 		"execute command on ns=%s, pod=%s container=%s, cmd: %s",
 		ctx.GetNamespace(),
 		ctx.GetPodName(),
 		ctx.GetContainerName(),
 		strings.Join(commandStr, " "),
-	))
+	)
 	req := clientsholder.K8sRestClient.Post().
 		Namespace(ctx.GetNamespace()).
 		Resource("pods").
@@ -105,7 +105,7 @@ func (clientsholder *Clientset) ExecCommandContainer(ctx ContainerContext, comma
 
 	exec, err := NewSPDYExecutor(clientsholder.RestConfig, "POST", req.URL())
 	if err != nil {
-		log.Error(err)
+		log.Debug(err)
 		return stdout, stderr, fmt.Errorf("error setting up remote command: %w", err)
 	}
 
@@ -115,11 +115,11 @@ func (clientsholder *Clientset) ExecCommandContainer(ctx ContainerContext, comma
 	})
 	stdout, stderr = buffOut.String(), buffErr.String()
 	if err != nil {
-		log.Error(err)
-		log.Error(req.URL())
-		log.Error("command: ", command)
-		log.Error("stderr: ", stderr)
-		log.Error("stdout: ", stdout)
+		log.Debug(err)
+		log.Debug(req.URL())
+		log.Debug("command: ", command)
+		log.Debug("stderr: ", stderr)
+		log.Debug("stdout: ", stdout)
 		return stdout, stderr, fmt.Errorf("error running remote command: %w", err)
 	}
 	return stdout, stderr, nil
@@ -130,13 +130,13 @@ func (clientsholder *Clientset) ExecCommandContainerStdIn(ctx ContainerContext, 
 	commandStr := command
 	var buffOut bytes.Buffer
 	var buffErr bytes.Buffer
-	log.Debug(fmt.Sprintf(
+	log.Debugf(
 		"execute command on ns=%s, pod=%s container=%s, cmd: %s",
 		ctx.GetNamespace(),
 		ctx.GetPodName(),
 		ctx.GetContainerName(),
 		strings.Join(commandStr, " "),
-	))
+	)
 	req := clientsholder.K8sRestClient.Post().
 		Namespace(ctx.GetNamespace()).
 		Resource("pods").
@@ -153,7 +153,7 @@ func (clientsholder *Clientset) ExecCommandContainerStdIn(ctx ContainerContext, 
 
 	exec, err := NewSPDYExecutor(clientsholder.RestConfig, "POST", req.URL())
 	if err != nil {
-		log.Error(err)
+		log.Debug(err)
 		return stdout, stderr, fmt.Errorf("error setting up remote command: %w", err)
 	}
 
@@ -164,12 +164,12 @@ func (clientsholder *Clientset) ExecCommandContainerStdIn(ctx ContainerContext, 
 	})
 	stdin, stdout, stderr := buffIn.String(), buffOut.String(), buffErr.String()
 	if err != nil {
-		log.Error(err)
-		log.Error(req.URL())
-		log.Error("command: ", command)
-		log.Error("stdin: ", stdin)
-		log.Error("stderr: ", stderr)
-		log.Error("stdout: ", stdout)
+		log.Debug(err)
+		log.Debug(req.URL())
+		log.Debug("command: ", command)
+		log.Debug("stdin: ", stdin)
+		log.Debug("stderr: ", stderr)
+		log.Debug("stdout: ", stdout)
 		return stdout, stderr, fmt.Errorf("error running remote command: %w", err)
 	}
 	return stdout, stderr, nil

--- a/pkg/collectors/devices/device_info.go
+++ b/pkg/collectors/devices/device_info.go
@@ -126,7 +126,7 @@ func GetPTPDeviceInfo(interfaceName string, ctx clients.ContainerContext) (PTPDe
 
 	err := fetcherInst.Fetch(ctx, &devInfo)
 	if err != nil {
-		log.Errorf("failed to fetch devInfo %s", err.Error())
+		log.Debugf("failed to fetch devInfo %s", err.Error())
 		return devInfo, fmt.Errorf("failed to fetch devInfo %w", err)
 	}
 	devInfo.GNSSDev = "/dev/" + devInfo.GNSSDev

--- a/pkg/collectors/devices/dpll.go
+++ b/pkg/collectors/devices/dpll.go
@@ -124,7 +124,7 @@ func GetDevDPLLInfo(ctx clients.ContainerContext, interfaceName string) (DevDPLL
 	}
 	err := fetcherInst.Fetch(ctx, &dpllInfo)
 	if err != nil {
-		log.Errorf("failed to fetch dpllInfo %s", err.Error())
+		log.Debugf("failed to fetch dpllInfo %s", err.Error())
 		return dpllInfo, fmt.Errorf("failed to fetch dpllInfo %w", err)
 	}
 	return dpllInfo, nil

--- a/pkg/collectors/devices/gps_ubx.go
+++ b/pkg/collectors/devices/gps_ubx.go
@@ -67,7 +67,6 @@ func init() {
 		true,
 	)
 	if err != nil {
-		log.Errorf("failed to add command %s %s", "GPS", err.Error())
 		panic(fmt.Errorf("failed to setup GPS fetcher %w", err))
 	}
 }
@@ -106,7 +105,7 @@ func GetGPSNav(ctx clients.ContainerContext) (GPSNav, error) {
 	gpsNav := GPSNav{}
 	err := gpsFetcher.Fetch(ctx, &gpsNav)
 	if err != nil {
-		log.Errorf("failed to fetch gpsNav %s", err.Error())
+		log.Debugf("failed to fetch gpsNav %s", err.Error())
 		return gpsNav, fmt.Errorf("failed to fetch gpsNav %w", err)
 	}
 	return gpsNav, nil

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -139,15 +139,15 @@ func runCommands(ctx clients.ContainerContext, cmdGrp clients.Cmder) (result map
 
 	stdout, _, err := clientset.ExecCommandContainerStdIn(ctx, command, buffIn)
 	if err != nil {
-		log.Errorf("command in container failed unexpectedly. context: %v", ctx)
-		log.Errorf("command in container failed unexpectedly. command: %v", command)
-		log.Errorf("command in container failed unexpectedly. error: %v", err)
+		log.Debugf("command in container failed unexpectedly. context: %v", ctx)
+		log.Debugf("command in container failed unexpectedly. command: %v", command)
+		log.Debugf("command in container failed unexpectedly. error: %v", err)
 		return result, fmt.Errorf("runCommands failed %w", err)
 	}
 	result, err = cmdGrp.ExtractResult(stdout)
 	if err != nil {
-		log.Errorf("extraction failed %s", err.Error())
-		log.Errorf("output was %s", stdout)
+		log.Debugf("extraction failed %s", err.Error())
+		log.Debugf("output was %s", stdout)
 		return result, fmt.Errorf("runCommands failed %w", err)
 	}
 	return result, nil


### PR DESCRIPTION
By shifting some log.Error calls to log.Debug we required higher levels of verbosity to see messages making the log less noisy